### PR TITLE
fixes missing serenity-screenplay-webdriver dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <serenity.version>1.1.42</serenity.version>
         <serenity.maven.version>1.1.42</serenity.maven.version>
-        <serenity.cucumber.version>1.1.10</serenity.cucumber.version>
+        <serenity.cucumber.version>1.1.11</serenity.cucumber.version>
         <parallel.tests>5</parallel.tests>
         <webdriver.base.url>http://todomvc.com/examples/angularjs/#/</webdriver.base.url>
         <encoding>UTF-8</encoding>


### PR DESCRIPTION
serenity-cucumber uses serenity-screenplay-webdriver with version 1.1.37-rc.7 but it is removed from mvnrepository. Updating serenity-cucumber version fixes dependency issue